### PR TITLE
Fix size attribute for empty files

### DIFF
--- a/fs-base/src/systemTest/java/com/palantir/giraffe/file/test/FileSystemReadAttributesTest.java
+++ b/fs-base/src/systemTest/java/com/palantir/giraffe/file/test/FileSystemReadAttributesTest.java
@@ -63,8 +63,18 @@ public class FileSystemReadAttributesTest extends FileSystemBaseTest {
         BasicFileAttributeView view = getView(path, BasicFileAttributeView.class);
         assertNotNull("BasicFileAttributeView is not available", view);
 
-        long time = view.readAttributes().size();
-        assertEquals("incorrect size", AttributeTestCreator.SIZE, time);
+        long size = view.readAttributes().size();
+        assertEquals("incorrect size", AttributeTestCreator.SIZE, size);
+    }
+
+    @Test
+    public void basicViewReadsEmptySize() throws IOException {
+        Path path = getTestPath(AttributeTestCreator.F_RO_EMPTY);
+        BasicFileAttributeView view = getView(path, BasicFileAttributeView.class);
+        assertNotNull("BasicFileAttributeView is not available", view);
+
+        long size = view.readAttributes().size();
+        assertEquals("incorrect size", 0, size);
     }
 
     @Test

--- a/fs-base/src/systemTest/java/com/palantir/giraffe/file/test/creator/AttributeTestCreator.java
+++ b/fs-base/src/systemTest/java/com/palantir/giraffe/file/test/creator/AttributeTestCreator.java
@@ -36,6 +36,7 @@ public class AttributeTestCreator implements Creator {
 
     public static final String F_RO_MODIFIED_TIME = "ro_modified_time.txt";
     public static final String F_RO_SIZE = "ro_size.txt";
+    public static final String F_RO_EMPTY = "ro_empty.txt";
     public static final String F_RO_PERMISSIONS = "ro_permissions.sh";
 
     public static final String F_RW_MODIFIED_TIME = "rw_modified_time.txt";
@@ -59,6 +60,7 @@ public class AttributeTestCreator implements Creator {
         script.setModifiedTime(F_RO_MODIFIED_TIME, new Date(MODIFIED_TIME.toMillis()));
 
         script.printf("dd if=/dev/zero bs=%d count=1 2>/dev/null > %s%n", SIZE, F_RO_SIZE);
+        script.createFile(F_RO_EMPTY);
 
         script.createFile(F_RO_PERMISSIONS, 0755);
 

--- a/ssh/src/main/java/com/palantir/giraffe/ssh/internal/base/SshPosixFileAttributes.java
+++ b/ssh/src/main/java/com/palantir/giraffe/ssh/internal/base/SshPosixFileAttributes.java
@@ -78,11 +78,7 @@ final class SshPosixFileAttributes implements AnnotatedPosixFileAttributes {
 
     @Override
     public long size() {
-        if (attrs.getSize() == 0L) {
-            return -1;
-        } else {
-            return attrs.getSize();
-        }
+        return attrs.getSize();
     }
 
     @Override


### PR DESCRIPTION
Due to a mistake when switching to SSHJ, we returned -1 as the size of an empty file, which makes no sense. Fixes #7.
