### PR TITLE
Check for loops in recursive copy

### DIFF
--- a/fs-base/src/main/java/com/palantir/giraffe/file/MoreFiles.java
+++ b/fs-base/src/main/java/com/palantir/giraffe/file/MoreFiles.java
@@ -23,7 +23,9 @@ import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -248,15 +250,27 @@ public final class MoreFiles {
      * @param source the path to copy
      * @param target the target path
      *
-     * @throws IllegalArgumentException if the destination already exists or one
-     *         or more parent directories do not exist.
+     * @throws FileAlreadyExistsException if the target already exists
+     * @throws NoSuchFileException if and parents of the target do not exist
      * @throws IOException if an I/O error occurs while copying
      */
     public static void copyRecursive(Path source, Path target) throws IOException {
-        checkArgument(!Files.exists(target),
-                "target (%s) already exists.", target.toAbsolutePath());
-        checkArgument(Files.isDirectory(target.getParent()),
-                "parent directory for target (%s) does not exist.", target.toAbsolutePath());
+        if (Files.exists(target)) {
+            throw new FileAlreadyExistsException(target.toString());
+        }
+
+        if (!Files.exists(target.getParent())) {
+            throw new NoSuchFileException(target.toString());
+        }
+
+        Path normalizedSource = source.normalize().toAbsolutePath();
+        Path normalizedTarget = target.normalize().toAbsolutePath();
+        if (normalizedTarget.startsWith(normalizedSource)) {
+            throw new FileSystemException(
+                    normalizedSource.toString(),
+                    normalizedTarget.toString(),
+                    "cannot copy a path into itself");
+        }
 
         FileSystemProvider sourceProvider = source.getFileSystem().provider();
         FileSystemProvider targetProvider = target.getFileSystem().provider();

--- a/fs-base/src/main/java/com/palantir/giraffe/file/MoreFiles.java
+++ b/fs-base/src/main/java/com/palantir/giraffe/file/MoreFiles.java
@@ -251,7 +251,7 @@ public final class MoreFiles {
      * @param target the target path
      *
      * @throws FileAlreadyExistsException if the target already exists
-     * @throws NoSuchFileException if and parents of the target do not exist
+     * @throws NoSuchFileException if any parents of the target do not exist
      * @throws IOException if an I/O error occurs while copying
      */
     public static void copyRecursive(Path source, Path target) throws IOException {

--- a/fs-base/src/test/java/com/palantir/giraffe/file/MoreFilesTest.java
+++ b/fs-base/src/test/java/com/palantir/giraffe/file/MoreFilesTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.giraffe.file;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests basic functionality of {@link MoreFiles} methods using the local file
+ * system.
+ *
+ * @author bkeyes
+ */
+public class MoreFilesTest {
+
+    @Rule
+    public final TemporaryFolder workingDir = new TemporaryFolder();
+
+    @Test(expected = FileAlreadyExistsException.class)
+    public void copyRecursiveFailsIfTargetExists() throws IOException {
+        Path source = workingDir.newFile("source").toPath();
+        Path target = workingDir.newFile("target").toPath();
+        MoreFiles.copyRecursive(source, target);
+    }
+
+    @Test(expected = NoSuchFileException.class)
+    public void copyRecursiveFailsIfTargetParentMissing() throws IOException {
+        Path source = workingDir.newFile("source").toPath();
+        Path parent = workingDir.getRoot().toPath().resolve("parent");
+        MoreFiles.copyRecursive(source, parent.resolve("target"));
+    }
+
+    @Test(expected = FileSystemException.class)
+    public void copyRecursiveFailsIfTargetInsideSource() throws IOException {
+        Path source = workingDir.newFile("source").toPath();
+        Path target = source.resolve("target").relativize(source);
+        MoreFiles.copyRecursive(source, target);
+    }
+
+}


### PR DESCRIPTION
Fixes #43. This is arguably an API-breaking change because it also changes the exceptions thrown under certain error conditions. However, since the signature does not change and we do not expect people to catch `IllegalArgumentException`, this should be safe.