### PR TITLE
Add system property for Kerberos debug output

### DIFF
--- a/ssh/src/main/java/com/palantir/giraffe/ssh/KerberosSshCredential.java
+++ b/ssh/src/main/java/com/palantir/giraffe/ssh/KerberosSshCredential.java
@@ -24,6 +24,13 @@ import java.io.IOException;
  */
 public class KerberosSshCredential extends SshCredential {
 
+    /**
+     * System property to enable Kerberos debug output when set to {@code true}.
+     * Note that debug output is verbose and is printed directly to standard
+     * out. This is a limitation of Java's Kerberos implementation.
+     */
+    public static final String DEBUG_PROPERTY = "giraffe.kerberos.debug";
+
     public static KerberosSshCredential of(String username) {
         return new KerberosSshCredential(username);
     }


### PR DESCRIPTION
Debug output is verbose and goes directly to standard out, so you don't really want this on all the time, but you also shouldn't have to change code just to debug Kerberos issues (which might be environmental).

Fixes part of #35.