### PR TITLE
Fix SharedByteArrayStream resize computation

### DIFF
--- a/core/src/main/java/com/palantir/giraffe/internal/SharedByteArrayStream.java
+++ b/core/src/main/java/com/palantir/giraffe/internal/SharedByteArrayStream.java
@@ -418,7 +418,7 @@ final class SharedByteArrayStream {
 
         // long to avoid int overflow during computation
         long additional = 0;
-        for (int i = 1; additional + available < needed; i++) {
+        for (int i = 1; additional + available <= needed; i++) {
             // double length each iteration (2^i - 1, to account for initial length)
             additional = (long) length * ((1 << i) - 1);
         }

--- a/core/src/test/java/com/palantir/giraffe/internal/SharedByteArrayStreamTest.java
+++ b/core/src/test/java/com/palantir/giraffe/internal/SharedByteArrayStreamTest.java
@@ -111,6 +111,12 @@ public class SharedByteArrayStreamTest {
     }
 
     @Test
+    public void computeResizeExact() {
+        int newLength = stream.computeResize(0, 3, 1);
+        assertEquals("length is incorrect", 8, newLength);
+    }
+
+    @Test
     public void computeResizeGrowsByPowersOf2() {
         int newLength = stream.computeResize(5, 100, 10);
         assertEquals("length is incorrect", 160, newLength);


### PR DESCRIPTION
The resize computation did lot leave space for the marker position in
the circular buffer, failing if the new value had exactly as much space
as was requested.