### PR TITLE
Upgrade Guava to 23.1-jre, sshj to 0.22.0, switch to Java 8

### DIFF
--- a/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestFilesPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestFilesPlugin.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.testing.Test;
 
 class SystemTestFilesPlugin implements Plugin<Project> {
 
@@ -45,6 +46,6 @@ class SystemTestFilesPlugin implements Plugin<Project> {
             commandLine createScriptTask.scriptPath, outputDir
         }
 
-        project.tasks['test'].dependsOn createFilesTask
+        project.tasks.withType(Test).all { test -> test.dependsOn createFilesTask }
     }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,13 @@ dependencies:
 
 test:
   override:
-    - ./gradlew build --console=plain --parallel
+    - ? >
+        case $CIRCLE_NODE_INDEX in
+        0) ./gradlew build --console=plain --parallel ;;
+        1) ./gradlew linuxIntegrationTest --console=plain --parallel ;;
+        esac
+      :
+        parallel: true
   post:
     - ./gradlew copyCircleArtifacts --console=plain --parallel
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: openjdk7
+    version: openjdk8
   post:
     - wget -O /tmp/github-release.tar.bz2 https://github.com/aktau/github-release/releases/download/v0.7.1/linux-amd64-github-release.tar.bz2
     - sudo tar -C /usr/local/bin --strip-components 3 -xf /tmp/github-release.tar.bz2

--- a/core/src/main/java/com/palantir/giraffe/command/CommandExitLatch.java
+++ b/core/src/main/java/com/palantir/giraffe/command/CommandExitLatch.java
@@ -121,7 +121,7 @@ public class CommandExitLatch {
                 public void run() {
                     finish(future);
                 }
-            }, MoreExecutors.sameThreadExecutor());
+            }, MoreExecutors.directExecutor());
         }
     }
 }

--- a/core/src/main/java/com/palantir/giraffe/command/ExecutionSystems.java
+++ b/core/src/main/java/com/palantir/giraffe/command/ExecutionSystems.java
@@ -146,7 +146,7 @@ public final class ExecutionSystems {
                     //TODO(jchien): Log
                 }
             }
-        }, MoreExecutors.sameThreadExecutor());
+        }, MoreExecutors.directExecutor());
     }
 
     /**

--- a/core/src/main/java/com/palantir/giraffe/command/interactive/CommandOutputTrigger.java
+++ b/core/src/main/java/com/palantir/giraffe/command/interactive/CommandOutputTrigger.java
@@ -34,7 +34,7 @@ public final class CommandOutputTrigger extends AbstractStreamWatcher {
      */
     public CommandOutputTrigger(ResponseProvider<Runnable> callbackMap,
                                 CommandFuture commandExecution) {
-        this(callbackMap, commandExecution, MoreExecutors.sameThreadExecutor());
+        this(callbackMap, commandExecution, MoreExecutors.directExecutor());
     }
 
     /**

--- a/core/src/test/java/com/palantir/giraffe/command/CommandsTest.java
+++ b/core/src/test/java/com/palantir/giraffe/command/CommandsTest.java
@@ -147,7 +147,7 @@ public class CommandsTest {
 
     @Test
     public void executeTimeoutExceeded() throws InterruptedException {
-        testTimeout("execute", executeCommandAction(10));
+        testTimeout("execute", executeCommandAction(20));
     }
 
     @Test

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -9,8 +9,8 @@ apply plugin: 'com.github.hierynomus.license'
 apply from: rootProject.file('gradle/versions.gradle')
 apply from: rootProject.file('gradle/circle.gradle')
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 version = rootProject.version
 group = rootProject.group

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,5 +1,5 @@
 ext.libVersions = [
-    guava:   '18.0',
+    guava:   '23.1-jre',
     slf4j:   '1.7.9',
     jsr305:  '2.0.3',
     junit:   '4.12',

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,7 +1,7 @@
 ext.libVersions = [
     guava:   '23.1-jre',
     slf4j:   '1.7.9',
-    jsr305:  '2.0.3',
+    jsr305:  '1.3.9',
     junit:   '4.12',
     mockito: '1.10.19',
     hamcrest: '1.3'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-4.2-bin.zip

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -38,6 +38,14 @@ test {
     include '**/EmbeddedSsh*Suite*'
 }
 
+task linuxIntegrationTest(type: Test) {
+    include '**/Linux*Suite*'
+
+    systemProperty 'giraffe.test.baseDir', '/home/ubuntu/giraffe/ssh/build/system-test-files'
+    systemProperty 'giraffe.test.host', 'ubuntu@localhost'
+    systemProperty 'giraffe.test.hostKey', '/home/ubuntu/.ssh/build_key.rsa'
+}
+
 jacocoCoverage {
     packageThreshold 0.45, 'com/palantir/giraffe'
 }

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':giraffe-core')
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
-    compile(group: 'com.hierynomus', name: 'sshj', version: '0.15.0') {
+    compile(group: 'com.hierynomus', name: 'sshj', version: '0.22.0') {
         // force our version of slf4j-api in a way that persists
         exclude module: 'slf4j-api'
     }

--- a/ssh/src/main/java/com/palantir/giraffe/ssh/internal/SshPosixFileAttributes.java
+++ b/ssh/src/main/java/com/palantir/giraffe/ssh/internal/SshPosixFileAttributes.java
@@ -68,7 +68,7 @@ final class SshPosixFileAttributes implements AnnotatedPosixFileAttributes {
 
     @Override
     public boolean isSymbolicLink() {
-        return attrs.getMode().getType() == Type.SYMKLINK;
+        return attrs.getMode().getType() == Type.SYMLINK;
     }
 
     @Override


### PR DESCRIPTION
This is motivated by Guava's announcement as of 23.1 that they'll be maintaining binary compatibility between Guava versions for the indefinite future (for non-`@Beta` APIs), instead of dropping deprecated features after 2 releases. Upgrading now should make it safe for our clients to override our version with any future release.

The JRE version of Guava now requires Java 8, so we're compiling with that as well. Since there haven't been any functional changes in a while, I think this will be fine. Hopefully anyone using the last Java 7 release will be able to switch to Java 8 by the time an important new feature or bug fix is added.

The Guava upgrade is probably pretty safe, but the SSHJ upgrade could do with some more testing. 