### PR TITLE
Upgrade Gradle, Guava, and fix documentation

### DIFF
--- a/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestFilesPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestFilesPlugin.groovy
@@ -35,7 +35,7 @@ class SystemTestFilesPlugin implements Plugin<Project> {
 
         def createFilesTask = project.task("create${c.taskName}TestFiles", type: Exec) {
             ext.outputDir = "${-> project.systemTestFiles.filesDir}/${c.name}"
-            inputs.file createScriptTask
+            inputs.files createScriptTask
             outputs.upToDateWhen { 
                 project.file(outputDir).exists() 
             }

--- a/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestPlugin.groovy
@@ -64,7 +64,7 @@ class SystemTestPlugin implements Plugin<Project> {
         def creatorCheck = project.task('checkCreatorJarHasNoDependencies', type: JavaExec) {
             ext.outputScript = new File(temporaryDir, 'creator-script.sh')
 
-            inputs.file creatorJar
+            inputs.files creatorJar
             outputs.file outputScript
 
             classpath creatorJar

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+git+https://github.com/obriencj/python-javatools.git
 sphinx>=1.3
-sphinx-javalink~=0.11.0
+sphinx-javalink~=0.11.1

--- a/docs/sphinx.gradle
+++ b/docs/sphinx.gradle
@@ -50,7 +50,7 @@ task cleanSphinxEnv {
 clean.dependsOn cleanSphinxEnv
 
 task installPackages(type: Exec, dependsOn: sphinxEnv) {
-    inputs.file 'requirements.txt'
+    inputs.files 'requirements.txt'
 
     // TODO(bkeyes): use site-packages dir instead
     outputs.file sphinxBinary

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -35,17 +35,17 @@ highlight_language = 'java'
 # Assume javadoc was already build by Gradle
 javalink_classpath = [
     javalink.find_rt_jar(),
-    '../../core/build/classes/main',
-    '../../ssh/build/classes/main',
-    '../../fs-base/build/classes/main'
+    '../../core/build/classes/java/main',
+    '../../ssh/build/classes/java/main',
+    '../../fs-base/build/classes/java/main'
 ]
 
 javalink_docroots = [
-    'http://docs.oracle.com/javase/7/docs/api/',
+    'http://docs.oracle.com/javase/8/docs/api/',
     {'root': '../build/javadoc', 'base': 'api'}
 ]
 
-javalink_default_version = 7
+javalink_default_version = 8
 javalink_add_package_names = False
 
 # -- Options for HTML output ----------------------------------------------

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -3,6 +3,7 @@
 //     apply from: javadoc.gradle, to: javadoc
 
 exclude '**/internal/**'
-options.links 'https://docs.oracle.com/javase/7/docs/api/'
+options.links 'https://docs.oracle.com/javase/8/docs/api/'
 options.links "https://google.github.io/guava/releases/${project.libVersions.guava}/api/docs/"
 options.links 'http://www.slf4j.org/apidocs/'
+options.addStringOption('Xdoclint:none', '-quiet')

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'checkstyle'
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.palantir.jacoco-coverage'
 apply plugin: 'com.github.hierynomus.license'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,5 +1,5 @@
 ext.libVersions = [
-    guava:   '23.1-jre',
+    guava:   '24.1-jre',
     slf4j:   '1.7.9',
     jsr305:  '1.3.9',
     junit:   '4.12',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-4.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':giraffe-core')
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
-    compile(group: 'com.hierynomus', name: 'sshj', version: '0.22.0') {
+    compile(group: 'com.hierynomus', name: 'sshj', version: '0.23.0') {
         // force our version of slf4j-api in a way that persists
         exclude module: 'slf4j-api'
     }


### PR DESCRIPTION
Fix documentation builds post Java 8 update and upgrade Gradle, Guava, and sshj again in preparation for an 0.9.0 release.