### PR TITLE
Use Gradle's java-library plugin

### DIFF
--- a/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestPlugin.groovy
@@ -16,17 +16,17 @@ class SystemTestPlugin implements Plugin<Project> {
         // add system test source set and configurations
         project.sourceSets.create(NAME)
         project.configurations.create(NAME) {
-            extendsFrom project.configurations[NAME + 'Compile']
+            extendsFrom project.configurations[NAME + 'Implementation']
         }
         project.configurations.create(CREATOR_NAME)
 
         // TODO(bkeyes): don't assume Eclipse exists
         project.eclipse.classpath {
-            plusConfigurations += [project.configurations[NAME + 'Compile']]
+            plusConfigurations += [project.configurations[NAME + 'Implementation']]
         }
 
         def deps = project.dependencies;
-        deps.add(NAME + 'Compile', deps.project(path: ':giraffe-test-util'))
+        deps.add(NAME + 'Implementation', deps.project(path: ':giraffe-test-util'))
 
         // define the main test jar task
         def testJar = project.task(NAME + 'Jar', type: Jar) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,15 +4,16 @@ apply plugin: 'giraffe.system-test'
 apply plugin: 'giraffe.system-test-files'
 
 dependencies {
-    compile project(':giraffe-fs-base')
+    api project(':giraffe-fs-base')
+    api group: 'com.google.guava', name: 'guava', version: libVersions.guava
+    api group: 'com.google.code.findbugs', name: 'jsr305', version: libVersions.jsr305
+    api group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
 
-    compile group: 'com.google.guava', name: 'guava', version: libVersions.guava
-    compile group: 'com.google.code.findbugs', name: 'jsr305', version: libVersions.jsr305
-    compile group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
+    testImplementation project(':giraffe-test-util')
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
+    systemTestImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: libVersions.hamcrest
 
-    testCompile project(':giraffe-test-util')
-    testCompile group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
-    testRuntime group: 'ch.qos.logback', name: 'logback-classic', version: libVersions.logback
+    testRuntimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: libVersions.logback
 }
 
 // configure the systemTest sourceset and configurations
@@ -29,7 +30,7 @@ creatorJar {
 // systemTest requires main code (for ES definitions)
 sourceSets.systemTest.compileClasspath += sourceSets.main.output
 configurations {
-    systemTestCompile.extendsFrom compile
+    systemTestImplementation.extendsFrom implementation
 }
 artifacts {
     systemTest jar

--- a/fs-base/build.gradle
+++ b/fs-base/build.gradle
@@ -3,10 +3,11 @@ apply from: '../gradle/shared.gradle'
 apply plugin: 'giraffe.system-test'
 
 dependencies {
-    compile group: 'com.google.guava', name: 'guava', version: libVersions.guava
-    compile group: 'com.google.code.findbugs', name: 'jsr305', version: libVersions.jsr305
+    api group: 'com.google.guava', name: 'guava', version: libVersions.guava
+    api group: 'com.google.code.findbugs', name: 'jsr305', version: libVersions.jsr305
 
-    testCompile group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
+    systemTestImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: libVersions.hamcrest
 }
 
 systemTest {

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'eclipse'
 apply plugin: 'checkstyle'
 apply plugin: 'maven-publish'
@@ -46,8 +47,8 @@ tasks.withType(Test).all { test ->
 dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:6.6'
 
-    testCompile group: 'junit', name: 'junit', version: libVersions.junit
-    testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: libVersions.hamcrest
+    testImplementation group: 'junit', name: 'junit', version: libVersions.junit
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: libVersions.hamcrest
 }
 
 apply from: rootProject.file('gradle/javadoc.gradle'), to: javadoc

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -3,23 +3,23 @@ apply from: '../gradle/shared.gradle'
 apply plugin: 'giraffe.system-test-files'
 
 dependencies {
-    compile project(':giraffe-core')
+    api project(':giraffe-core')
+    api group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
 
-    compile group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
-    compile(group: 'com.hierynomus', name: 'sshj', version: libVersions.sshj) {
+    implementation(group: 'com.hierynomus', name: 'sshj', version: libVersions.sshj) {
         // force our version of slf4j-api in a way that persists
         exclude module: 'slf4j-api'
     }
 
-    testCompile project(path: ':giraffe-fs-base', configuration: 'systemTest')
-    testCompile project(path: ':giraffe-core', configuration: 'systemTest')
-
-    testCompile(group: 'org.apache.sshd', name: 'sshd-core', version: libVersions.sshd) {
+    testImplementation project(path: ':giraffe-fs-base', configuration: 'systemTest')
+    testImplementation project(path: ':giraffe-core', configuration: 'systemTest')
+    testImplementation(group: 'org.apache.sshd', name: 'sshd-core', version: libVersions.sshd) {
         // exclude optional Maven dependencies
         exclude module: 'tomcat-apr'
     }
-    testCompile(group: 'org.apache.sshd', name: 'sshd-sftp', version: libVersions.sshd)
-    testRuntime group: 'ch.qos.logback', name: 'logback-classic', version: libVersions.logback
+    testImplementation(group: 'org.apache.sshd', name: 'sshd-sftp', version: libVersions.sshd)
+
+    testRuntimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: libVersions.logback
 }
 
 systemTestFiles {

--- a/test-util/build.gradle
+++ b/test-util/build.gradle
@@ -1,6 +1,5 @@
 apply from: '../gradle/shared.gradle'
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: libVersions.junit
-    compile group: 'org.hamcrest', name: 'hamcrest-library', version: libVersions.hamcrest
+    api group: 'junit', name: 'junit', version: libVersions.junit
 }


### PR DESCRIPTION
This should make the generated POMs better reflect the actual public API
contracts, with only Guava and SLF4J as dependencies.