### PR TITLE
Use gradle-git-version instead of flexversion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,12 @@
 plugins {
-    id "com.palantir.flexversion" version "0.9.2"
+    id "com.palantir.git-version" version "0.11.0"
     id "com.palantir.jacoco-coverage" version "0.4.0" apply false
     id "com.github.hierynomus.license" version "0.13.1" apply false
 }
 
 apply from: 'gradle/versions.gradle'
 
-addPrintVersionTask()
-flexversion {
-    envvarSources << 'CIRCLE_BRANCH'
-    useTags = true
-}
-
-version flexVersion()
+version gitVersion()
 group = 'com.palantir.giraffe'
 
 ext.localPublishDir = "${buildDir}/m2"


### PR DESCRIPTION
Flexversion is unmaintained, so use the simpler git-version instead.
This also means future releases will be tagged directly on the develop
branch and the master branch will be deleted.

Fixes #64.