### PR TITLE
Fix dependency resolution for Eclipse

### DIFF
--- a/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/palantir/giraffe/gradle/test/SystemTestPlugin.groovy
@@ -22,7 +22,7 @@ class SystemTestPlugin implements Plugin<Project> {
 
         // TODO(bkeyes): don't assume Eclipse exists
         project.eclipse.classpath {
-            plusConfigurations += [project.configurations[NAME + 'Implementation']]
+            plusConfigurations += [project.configurations[NAME]]
         }
 
         def deps = project.dependencies;


### PR DESCRIPTION
Use the systemTest configuration instead of the internally-generated
systemTestImplementation configuration.