### PR TITLE
fix thread leak

### DIFF
--- a/ssh/src/main/java/com/palantir/giraffe/ssh/internal/SshHostControlSystem.java
+++ b/ssh/src/main/java/com/palantir/giraffe/ssh/internal/SshHostControlSystem.java
@@ -98,10 +98,19 @@ public final class SshHostControlSystem extends AbstractHostControlSystem {
             checkNotNull(fs, "file system not set");
             checkNotNull(es, "execution system not set");
 
-            SshHostControlSystem system = new SshHostControlSystem(this);
-            fs.setSourceSystem(system);
-            es.setSourceSystem(system);
-            return system;
+            try {
+                SshHostControlSystem system = new SshHostControlSystem(this);
+                fs.setSourceSystem(system);
+                es.setSourceSystem(system);
+                return system;
+            } catch (Throwable t) {
+                try {
+                    request.getCloseContext().close();
+                } catch (IOException e) {
+                    t.addSuppressed(e);
+                }
+                throw t;
+            }
         }
     }
 


### PR DESCRIPTION
If the SshHostControlSystem constructor throws, then it will not be
closed.