### PR TITLE
Pin Sphinx to 1.8.5 and use Python 2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/obriencj/python-javatools.git
-sphinx>=1.3
+sphinx~=1.8.5
 sphinx-javalink~=0.11.1

--- a/docs/sphinx.gradle
+++ b/docs/sphinx.gradle
@@ -36,7 +36,7 @@ task installVirtualenv(type: Copy) {
 
 task sphinxEnv(type: Exec, dependsOn: installVirtualenv) {
     outputs.dir sphinxEnvDir
-    commandLine 'python', "${installVirtualenv.virtualenvDir}/virtualenv.py", sphinxEnvDir
+    commandLine 'python2', "${installVirtualenv.virtualenvDir}/virtualenv.py", sphinxEnvDir
 }
 
 task cleanSphinxEnv {


### PR DESCRIPTION
While Python 2 is almost EOL, when I last checked, the javatools library
was not compatible with Python 3 yet, and by extension, my
sphinx-javalink plugin was not compatible either.