### PR TITLE
add option to specify keepalive interval for ssh connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ build/
 .settings/
 bin/
 
+# IDEA files
+.idea/
+
 # Sphinx/Python files
 *.pyc

--- a/ssh/src/main/java/com/palantir/giraffe/ssh/SshSystemRequest.java
+++ b/ssh/src/main/java/com/palantir/giraffe/ssh/SshSystemRequest.java
@@ -35,6 +35,7 @@ public class SshSystemRequest extends AuthenticatedSystemRequest<SshCredential> 
 
     public static final String PORT_KEY = "port";
     public static final String LOGGER_KEY = "logger";
+    public static final String KEEPALIVE_INTERVAL_KEY = "keepalive_interval";
 
     private static final String DEFAULT_LOGGER_NAME = "com.palantir.giraffe.ssh";
 
@@ -56,6 +57,8 @@ public class SshSystemRequest extends AuthenticatedSystemRequest<SshCredential> 
     private void setDefaults() {
         setPort(uri().getPort());
         setLogger(LoggerFactory.getLogger(DEFAULT_LOGGER_NAME));
+        // by default, no keepalive
+        setKeepaliveInterval(0);
     }
 
     public int getPort() {
@@ -72,6 +75,14 @@ public class SshSystemRequest extends AuthenticatedSystemRequest<SshCredential> 
 
     public void setLogger(Logger logger) {
         set(LOGGER_KEY, logger);
+    }
+
+    public int getKeepaliveInterval() {
+        return get(KEEPALIVE_INTERVAL_KEY, Integer.class);
+    }
+
+    public void setKeepaliveInterval(int keepaliveInterval) {
+        set(KEEPALIVE_INTERVAL_KEY, keepaliveInterval);
     }
 
     public String getUsername() {

--- a/ssh/src/main/java/com/palantir/giraffe/ssh/internal/SshConnectionFactory.java
+++ b/ssh/src/main/java/com/palantir/giraffe/ssh/internal/SshConnectionFactory.java
@@ -53,6 +53,10 @@ final class SshConnectionFactory {
     public SSHClient newAuthedConnection(SshSystemRequest request) throws IOException {
         SSHClient sshClient = new SSHClient(config);
         sshClient.getTransport().addHostKeyVerifier(new PromiscuousVerifier());
+        if (request.getKeepaliveInterval() > 0) {
+            sshClient.getConnection().getKeepAlive().setKeepAliveInterval(
+                    request.getKeepaliveInterval());
+        }
 
         try {
             sshClient.connect(request.uri().getHost(), request.getPort());


### PR DESCRIPTION
Note that by default, sshj uses an old "heartbeat" message for
keepalives, which is a standard ssh packet. It's actually possible to
configure it to instead use ssh protocol keepalive messages, but doing
so requires setting the keepalive provider in the Config objecct that's
passed to SshConnectorFactory. That's buried in some abstraction, so
this change doesn't actually allow turning on real ssh keepalives
directly, and instead uses the default heartbeating method.