### PR TITLE
Use standard plugin for Maven Central publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ try (HostControlSystem hcs = ssh.open()) {
 
 ## Get Giraffe
 
-Giraffe is available from [JCenter][jcenter] or Palantir's [Bintray repository][bintray].
+Giraffe is available from [Maven Central][maven-central].
 
 With **Gradle**:
 
 ```gradle
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -44,8 +44,7 @@ dependencies {
 }
 ```
 
-[jcenter]: https://bintray.com/bintray/jcenter
-[bintray]: http://dl.bintray.com/palantir/releases
+[maven-central]: https://repo1.maven.org/maven2/com/palantir/giraffe/
 
 ## Why Giraffe?
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id "com.palantir.git-version" version "0.12.3"
+    id "com.palantir.external-publish" version "1.2.1"
+
     id "com.palantir.jacoco-coverage" version "0.4.0" apply false
     id "com.github.hierynomus.license" version "0.13.1" apply false
-    id "com.jfrog.bintray" version "1.8.5" apply false
 }
 
 apply from: 'gradle/versions.gradle'

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -16,7 +16,7 @@ Gradle_ for builds:
 .. code-block:: groovy
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -2,10 +2,9 @@ apply plugin: 'java'
 apply plugin: 'java-library'
 apply plugin: 'eclipse'
 apply plugin: 'checkstyle'
-apply plugin: 'maven-publish'
 apply plugin: 'com.palantir.jacoco-coverage'
 apply plugin: 'com.github.hierynomus.license'
-apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.palantir.external-publish-jar'
 
 apply from: rootProject.file('gradle/versions.gradle')
 apply from: rootProject.file('gradle/circle.gradle')
@@ -61,49 +60,6 @@ license {
     ext.year = Calendar.getInstance().get(Calendar.YEAR)
 
     include '**/*.java'
-}
-
-task sourceJar(type: Jar) {
-    from sourceSets.main.allSource
-    classifier 'sources'
-}
-
-publishing {
-    publications {
-        java(MavenPublication) {
-            from components.java
-
-            artifact(sourceJar) {
-                classifier 'sources'
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name "local"
-            url localPublishDir
-        }
-    }
-}
-
-bintray {
-  user = System.env.BINTRAY_USERNAME
-  key = System.env.BINTRAY_PASSWORD
-  publish = true
-  pkg {
-    repo = 'releases'
-    name = 'giraffe'
-    userOrg = 'palantir'
-    licenses = ['Apache-2.0']
-    vcsUrl = 'https://github.com/palantir/giraffe.git'
-    publications = ['java']
-  }
-}
-
-publish.dependsOn bintrayUpload
-bintrayUpload.onlyIf {
-    versionDetails().isCleanTag && System.env.BINTRAY_USERNAME && System.env.BINTRAY_PASSWORD
 }
 
 task resolveDependencies {


### PR DESCRIPTION
Remove publishing to Bintray as the service is deprecated.