### PR TITLE
Use modern CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ common:
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8u181-jdk
+      - image: cimg/openjdk:8.0.402
     environment: *environment
     steps:
       - checkout
@@ -54,7 +54,7 @@ jobs:
 
   integration-test:
     docker:
-      - image: circleci/openjdk:8u181-jdk
+      - image: cimg/openjdk:8.0.402
       - image: sickp/alpine-sshd:7.5-r2
     environment: *environment
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/openjdk:8u181-jdk
+      - image: cimg/openjdk:8.0.402
     environment: *environment
     steps:
       - checkout


### PR DESCRIPTION
Still build with Java 8 for now because I'm not sure what the consequences of moving to a new version will be.